### PR TITLE
Update CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,49 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [2.0.0] - 2024-11-06
-
-### 🚜 Refactor
-
-- **BREAKING**: Remove Jetpack Compose tracking functionality - The entire `:compose` module, `@TrackScreenComposable` annotation, and related Compose-specific instrumentation have been removed to focus the library on bytecode transformation for Activities and Fragments
-- Remove `trackActivities` and `trackFragments` from extension - These configuration options are now obsolete as the presence of a `@TrackScreen` annotation is sufficient to enable tracking
-- **Centralize instrumentation logic** and add helper classes:
-  - Introduced `AnalyticsConstants.kt` for centralized constant management
-  - Introduced `AnnotationMetadata.kt` for type-safe annotation metadata handling
-  - Introduced `AnnotationExtractor.kt` for clean annotation parameter parsing
-  - Introduced `ClassTypeDetector.kt` for Activity/Fragment type detection
-  - Introduced `MethodInstrumentationStrategy.kt` for instrumentation strategy selection
-  - Introduced `LifecycleInstrumentingMethodVisitor.kt` for lifecycle method injection
-  - Introduced `TrackingLogger.kt` for optimized lazy-evaluation logging
-- **Centralize error handling** with a global `errorHandler` - Moved `errorHandler` from `MethodTrackingConfig` to `AnalyticsConfig` level for unified analytics error management across screen tracking, event logging, and method tracking
+## [2.1.0] - 2025-11-12
 
 ### 📚 Documentation
 
-- Update README with simplified configuration - Removed references to Compose, removed obsolete configuration properties (`trackActivities`, `trackFragments`, `trackComposables`), and updated examples to reflect current API
-
-## [1.0.1] - 2025-10-03
-
-### 🚀 Features
-
-- Introduce `TrackScreenOnce` composable for reliable screen tracking
-- Introduce TrackScreenHelper for ASM-injected code
+- Update version to 2.0.0 in README files ([#10](https://github.com/sh3lan93/analytics-annotation/issues/10))
 
 ### ⚙️ Miscellaneous Tasks
 
-- Add extensive KDoc documentation to `AnalyticsClassVisitorFactory`
-- Bump version to 1.0.1
-- Bump plugin version to 1.0.1
+- Use Extracted @TrackScreen Annotation Parameters in Bytecode Instrumentation ([#11](https://github.com/sh3lan93/analytics-annotation/issues/11))
 
-### Chore
-- Bump version to 1.0.1
+## [2.0.0] - 2025-11-10
 
-### Refactor
+### 🚀 Features
 
-- **compose**: Use `TrackScreenOnce` for Composable screen tracking
-- Simplify tracking method injection with a helper class
-- Remove unused variable in `AnalyticsClassVisitorFactory`
-- Remove unused class properties in `AnalyticsClassVisitor`
-- Relocate `TrackingAnnotationInfo` and remove `AnnotationScanner`
+- Add automated release workflow ([#9](https://github.com/sh3lan93/analytics-annotation/issues/9))
+
+## [1.0.1] - 2025-10-03
+
+### Docs
+
+- Add .claude to .gitignore
+- Update README
 
 ## [1.0.0] - 2025-09-24
 
@@ -92,6 +71,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Update GitHub Actions and improve security for PRs
 - Update relative links to absolute URLs in README
 - Remove separate dependency check job
+- Add CHANGELOG.md and cliff.toml configuration
 
 ### Build
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,18 +15,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Use Extracted @TrackScreen Annotation Parameters in Bytecode Instrumentation ([#11](https://github.com/sh3lan93/analytics-annotation/issues/11))
 
-## [2.0.0] - 2025-11-10
+## [2.0.0] - 2024-11-06
 
-### 🚀 Features
+### 🚜 Refactor
 
-- Add automated release workflow ([#9](https://github.com/sh3lan93/analytics-annotation/issues/9))
+- **BREAKING**: Remove Jetpack Compose tracking functionality - The entire `:compose` module, `@TrackScreenComposable` annotation, and related Compose-specific instrumentation have been removed to focus the library on bytecode transformation for Activities and Fragments
+- Remove `trackActivities` and `trackFragments` from extension - These configuration options are now obsolete as the presence of a `@TrackScreen` annotation is sufficient to enable tracking
+- **Centralize instrumentation logic** and add helper classes:
+  - Introduced `AnalyticsConstants.kt` for centralized constant management
+  - Introduced `AnnotationMetadata.kt` for type-safe annotation metadata handling
+  - Introduced `AnnotationExtractor.kt` for clean annotation parameter parsing
+  - Introduced `ClassTypeDetector.kt` for Activity/Fragment type detection
+  - Introduced `MethodInstrumentationStrategy.kt` for instrumentation strategy selection
+  - Introduced `LifecycleInstrumentingMethodVisitor.kt` for lifecycle method injection
+  - Introduced `TrackingLogger.kt` for optimized lazy-evaluation logging
+- **Centralize error handling** with a global `errorHandler` - Moved `errorHandler` from `MethodTrackingConfig` to `AnalyticsConfig` level for unified analytics error management across screen tracking, event logging, and method tracking
+
+### 📚 Documentation
+
+- Update README with simplified configuration - Removed references to Compose, removed obsolete configuration properties (`trackActivities`, `trackFragments`, `trackComposables`), and updated examples to reflect current API
 
 ## [1.0.1] - 2025-10-03
 
-### Docs
+### 🚀 Features
 
-- Add .claude to .gitignore
-- Update README
+- Introduce `TrackScreenOnce` composable for reliable screen tracking
+- Introduce TrackScreenHelper for ASM-injected code
+
+### ⚙️ Miscellaneous Tasks
+
+- Add extensive KDoc documentation to `AnalyticsClassVisitorFactory`
+- Bump version to 1.0.1
+- Bump plugin version to 1.0.1
+
+### Chore
+- Bump version to 1.0.1
+
+### Refactor
+
+- **compose**: Use `TrackScreenOnce` for Composable screen tracking
+- Simplify tracking method injection with a helper class
+- Remove unused variable in `AnalyticsClassVisitorFactory`
+- Remove unused class properties in `AnalyticsClassVisitor`
+- Relocate `TrackingAnnotationInfo` and remove `AnnotationScanner`
 
 ## [1.0.0] - 2025-09-24
 


### PR DESCRIPTION
## Summary

  This PR updates the CHANGELOG.md to document the v2.1.0 release. 

  ## Version Info

  - **Previous Release**: v2.0.0 (2025-11-06)
  - **New Release**: v2.1.0 (2025-11-12)

  ## What This Addresses
  - Ensures the changelog accurately reflects all changes in the v2.1.0 release
